### PR TITLE
Patch 1.2.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Pokéstar Changelog
 
+### 1.2.1 Twitch Plays Pokemon (Re-Run)
+
+- Bring back TPP limited time
+- Some buffs
+
 **Stretch**
 
 - Stretch: Quests (Achievements)

--- a/changelog.md
+++ b/changelog.md
@@ -1,14 +1,17 @@
 # Pokéstar Changelog
 
-### 1.2.1 Twitch Plays Pokemon (Re-Run)
-
-- Bring back TPP limited time
-- Some buffs
-
 **Stretch**
 
 - Stretch: Quests (Achievements)
 - Stretch: Ability slots
+
+### 1.2.1 Twitch Plays Pokemon (Re-Run)
+
+- Twitch Plays Pokemon Re-run: Celebrating Twitch Plays Pokemon Anniversary
+  - Catch limited time TPP-inspired Pokemon in `/gacha`
+  - Play limited time `/pve` and `/dungeons`
+  - Buffed AA-j and AIR
+- (Experimental) Buffed the average spawn delay 2hrs -> 1hr
 
 ## 1.2.0 Gen 3 Wrap-Up (Aqua vs. Magma) (2/1)
 

--- a/src/config/battleConfig.js
+++ b/src/config/battleConfig.js
@@ -6275,7 +6275,7 @@ const moveConfig = Object.freeze({
     tier: moveTiers.ULTIMATE,
     damageType: damageTypes.OTHER,
     description:
-      "The user uses all available HM moves against the target. If the HM move is on cooldown, reset the cooldown instead of using the move.",
+      "The user sharply raises its attacking stats for 1 turn. The user then uses all available HM moves against the target. If the HM move is on cooldown, reset the cooldown instead of using the move.",
   },
   m20003: {
     name: "Rocket Thievery",
@@ -11683,6 +11683,10 @@ const moveExecutes = {
   m20002(battle, source, _primaryTarget, allTargets, _missedTargets) {
     const moveId = "m20002";
     const moveData = getMove(moveId);
+    // sharply boost atk and spa
+    source.applyEffect("greaterAtkUp", 3, source);
+    source.applyEffect("greaterSpaUp", 3, source);
+
     for (const target of allTargets) {
       // use all HM moves
       const hmMoveIds = ["m57", "m70", "m127", "m249"];
@@ -15730,7 +15734,7 @@ const abilityConfig = Object.freeze({
   20007: {
     name: "Bloody Sunday",
     description:
-      "Whenever an ally Pokemon faints, increase the user's combat readiness to 100%.",
+      "Whenever an ally Pokemon faints, increase the user's combat readiness to 100% and heal 10% HP.",
     abilityAdd(battle, _source, target) {
       const listener = {
         initialArgs: {
@@ -15749,6 +15753,14 @@ const abilityConfig = Object.freeze({
               `${targetPokemon.name} has been sacrificed to ${initialArgs.pokemon.name}'s Bloody Sunday!`
             );
             initialArgs.pokemon.boostCombatReadiness(initialArgs.pokemon, 100);
+            initialArgs.pokemon.giveHeal(
+              Math.floor(initialArgs.pokemon.maxHp * 0.1),
+              initialArgs.pokemon,
+              {
+                type: "ability",
+                id: "20007",
+              }
+            );
           }
         },
       };

--- a/src/config/commandConfig.js
+++ b/src/config/commandConfig.js
@@ -784,6 +784,7 @@ const commandConfigRaw = {
           "palmer",
           "professorWillow",
           "butler",
+          "tppRed",
         ],
       },
       difficulty: {

--- a/src/config/gachaConfig.js
+++ b/src/config/gachaConfig.js
@@ -91,6 +91,18 @@ const bannerTypeConfig = Object.freeze({
 const bannerConfigRaw = [
   {
     bannerType: bannerTypes.SPECIAL,
+    name: "[EVENT] Twitch Plays Pokemon Anniversary",
+    description:
+      "The Twitch Plays Pokemon banner is back for its anniversary! Pull to get the limited-time iconic Pokemon from the original Twitch Plays Pokemon Red! For more information, use `/events`.",
+    rateUp: () => ({
+      [rarities.LEGENDARY]: ["139-1", "145-1", "136-1"],
+      [rarities.EPIC]: ["18-1", "34-1", "49-1", "131-1"],
+    }),
+    image:
+      "https://raw.githubusercontent.com/ewei068/pokestar/main/media/images/events/pokestar-tpp-banner.png",
+  },
+  {
+    bannerType: bannerTypes.SPECIAL,
     name: "[EVENT] Team Aqua Banner",
     description:
       "Team Aqua is here to conquer the seas! Pull for the limited Aqua Leader Archie's Kyogre and Team Aqua's Sharpedo!",

--- a/src/config/helpConfig.js
+++ b/src/config/helpConfig.js
@@ -30,6 +30,21 @@ The Twitch Plays Pokemon mini-event has arrived! Including new PvE content and l
 * Bloody Sunday Art: https://imgur.com/70oeGPX
 `;
 
+const TPP_RERUN_DESCRIPTION = `🎮**Twitch Plays Pokemon (Re-run)**🎮
+
+To celebrate the Twitch Plays Pokemon Anniversary, the Twitch Plays Pokemon mini-event has returned! Including new PvE content and limited custom Pokemon!
+
+🧢 **Twitch Plays Red:** Fight the limited-time event trainer Twitch Plays Red! Defeat him every day to get 2 free <:greatball:1100296107759779840> Greatballs! Use \`/pve tppRed\` to challenge him!
+
+🖥️ **Bloody Sunday:** Re-live the historic Bloody Sunday with the new limited-time dungeon, giving 7 of each equipment shards! Use \`/dungeons\` to challenge it!
+
+<:lordhelix:1114224346873991268> **Event Pokemon:** Powerful custom event Pokemon from Twitch Plays Pokemon are now available for a limited time! Use \`/gacha\` to try your luck!
+
+🖌️ **Art Credits**:
+* Shiny Event Pokemon Sprites: [hamigakimomo](https://hamigakimomo.tumblr.com/post/77911455524/i-decided-to-make-custom-rb-sprites-for-the)
+* Bloody Sunday Art: https://imgur.com/70oeGPX
+`;
+
 const ROCKET_DESCRIPTION = `🚀**Team Rocket Takeover**🚀
 
 As we wrap up Gen 1, Team Rocket has taken over Pokestar! Defeat special stages, collect limited Pokemon, and catch the Mythical Mew!
@@ -158,6 +173,12 @@ Team Aqua and Team Magma are clashing for control of the climate in Pokestar!
  * @type {EventData[]}
  */
 const gameEventConfig = [
+  {
+    name: "Twitch Plays Pokemon (Re-run)",
+    description: TPP_DESCRIPTION,
+    image:
+      "https://raw.githubusercontent.com/ewei068/pokestar/main/media/images/events/pokestar-tpp-banner.png",
+  },
   {
     name: "Aqua vs Magma",
     description: AQUA_VS_MAGMA_DESCRIPTION,

--- a/src/config/npcConfig.js
+++ b/src/config/npcConfig.js
@@ -19,7 +19,7 @@ const npcs = Object.freeze({
   RED: "red",
   GOLD: "gold",
   STEVEN: "steven",
-  // TWITCH_PLAYS_RED: "tppRed",
+  TWITCH_PLAYS_RED: "tppRed",
   FISHERMAN: "fisherman",
   HIKER: "hiker",
   AROMA_LADY: "aromaLady",
@@ -661,6 +661,29 @@ const npcConfig = Object.freeze({
       },
     },
   },
+  [npcs.TWITCH_PLAYS_RED]: {
+    name: "Twitch Plays Red",
+    sprite:
+      "https://archives.bulbagarden.net/media/upload/6/66/Spr_RG_Red_1.png",
+    emoji: "<:tppRed:1117871510804254760>",
+    catchphrase: "⬆⬆⬇⬇⬅➔⬅➔BAAAAAAAAAAAAAAAAA",
+    difficulties: {
+      [difficulties.VERY_HARD]: {
+        minLevel: 90,
+        maxLevel: 100,
+        numPokemon: 6,
+        pokemonIds: ["18-1", "34-1", "49-1", "131-1", "145-1"],
+        aceId: "139-1",
+        dailyRewards: {
+          backpack: {
+            [backpackCategories.POKEBALLS]: {
+              [backpackItems.GREATBALL]: 2,
+            },
+          },
+        },
+      },
+    },
+  },
   /* [npcs.STRAW_HATS]: {
         name: "Straw Hats",
         sprite: "https://raw.githubusercontent.com/ewei068/pokestar/main/media/images/sprites/luffy-resized.png",
@@ -696,31 +719,8 @@ const npcConfig = Object.freeze({
                 }
             },
         }
-    },
-
-    /*[npcs.TWITCH_PLAYS_RED]: {
-        name: "Twitch Plays Red",
-        sprite: "https://archives.bulbagarden.net/media/upload/6/66/Spr_RG_Red_1.png",
-        emoji: "<:tppRed:1117871510804254760>",
-        catchphrase: "⬆⬆⬇⬇⬅➔⬅➔BAAAAAAAAAAAAAAAAA",
-        difficulties: {
-            [difficulties.VERY_HARD]: {
-                minLevel: 90,
-                maxLevel: 100,
-                numPokemon: 6,
-                pokemonIds: ["18-1", "34-1", "49-1", "131-1", "145-1"],
-                aceId: "139-1",
-                dailyRewards: {
-                    backpack: {
-                        [backpackCategories.POKEBALLS]: {
-                            [backpackItems.GREATBALL]: 2,
-                        },
-                    }
-                }
-            },
-        }
-    },
-    [npcs.TEAM_ROCKET]: {
+    }, 
+     [npcs.TEAM_ROCKET]: {
         name: "Team Rocket",
         sprite: "https://archives.bulbagarden.net/media/upload/8/8f/Spr_Y_Jessie_James.png",
         emoji: "<:james:1117871387399426090><:jessie:1117871388653531167>",
@@ -1084,7 +1084,7 @@ const dungeons = Object.freeze({
   NEW_ISLAND: "newIsland",
   SOOTOPOLIS_CITY: "sootopolisCity",
   // ONIGASHIMA: "onigashima",
-  // BLOODY_SUNDAY: "bloodySunday",
+  BLOODY_SUNDAY: "bloodySunday",
 });
 
 const dungeonConfig = Object.freeze({
@@ -2345,9 +2345,9 @@ const dungeonConfig = Object.freeze({
         rewards: {
           backpack: {
             [backpackCategories.MATERIALS]: {
-              [backpackItems.KNOWLEDGE_SHARD]: 10,
-              [backpackItems.EMOTION_SHARD]: 10,
-              [backpackItems.WILLPOWER_SHARD]: 10,
+              [backpackItems.KNOWLEDGE_SHARD]: 15,
+              [backpackItems.EMOTION_SHARD]: 15,
+              [backpackItems.WILLPOWER_SHARD]: 15,
             },
           },
         },
@@ -2512,131 +2512,132 @@ const dungeonConfig = Object.freeze({
                 },
             },
         }
-    },
-    /*[dungeons.BLOODY_SUNDAY]: {
-        name: "Bloody Sunday",
-        sprite: "https://external-preview.redd.it/mJjUWHxEKQ674NI4m7hUSJ108UlpTgTH2vWSmwMHfdA.jpg?auto=webp&s=6c0601add4b5a74185844ebaff16bebb3ada41a5",
-        emoji: "🖥️",
-        description: `The site of the terrifying massacre and sacrifice known as Bloody Sunday. First, capture Zapdos from the Power Plant. Then, retrieve it from the PC...`,
-        bosses: ["136-1", "145-1"],
-        difficulties: {
-            [difficulties.HARD]: {
-                phases: [
-                    {
-                        rows: 3,
-                        cols: 5,
-                        pokemons: [
-                            {
-                                speciesId: "145",
-                                level: 90,
-                                position: 8,
-                            },
-                            {
-                                speciesId: "101",
-                                level: 85,
-                                position: 11,
-                            },
-                            {
-                                speciesId: "82",
-                                level: 85,
-                                position: 12,
-                            },
-                            {
-                                speciesId: "26",
-                                level: 85,
-                                position: 13,
-                            },
-                            {
-                                speciesId: "82",
-                                level: 85,
-                                position: 14,
-                            },
-                            {
-                                speciesId: "101",
-                                level: 85,
-                                position: 15,
-                            },
-                        ]
-                    },
-                    {
-                        rows: 3,
-                        cols: 5,
-                        pokemons: [
-                            {
-                                speciesId: "32",
-                                level: 95,
-                                position: 1,
-                            },
-                            {
-                                speciesId: "44",
-                                level: 95,
-                                position: 2,
-                            },
-                            {
-                                speciesId: "20",
-                                level: 95,
-                                position: 3,
-                            },
-                            {
-                                speciesId: "83",
-                                level: 95,
-                                position: 4,
-                            },
-                            {
-                                speciesId: "32",
-                                level: 95,
-                                position: 5,
-                            },
-                            {
-                                speciesId: "48",
-                                level: 95,
-                                position: 6,
-                            },
-                            {
-                                speciesId: "46",
-                                level: 95,
-                                position: 7,
-                            },
-                            {
-                                speciesId: "74",
-                                level: 95,
-                                position: 8,
-                            },
-                            {
-                                speciesId: "102",
-                                level: 95,
-                                position: 9,
-                            },
-                            {
-                                speciesId: "48",
-                                level: 95,
-                                position: 10,
-                            },
-                            {
-                                speciesId: "136-1",
-                                level: 100,
-                                position: 12,
-                            },
-                            {
-                                speciesId: "145-1",
-                                level: 100,
-                                position: 14,
-                            },
-                        ]
-                    },
-                ],
-                rewards: {
-                    backpack: {
-                        [backpackCategories.MATERIALS]: {
-                            [backpackItems.KNOWLEDGE_SHARD]: 2,
-                            [backpackItems.EMOTION_SHARD]: 2,
-                            [backpackItems.WILLPOWER_SHARD]: 2,
-                        },
-                    }
-                }
-            },
-        },
     }, */
+  [dungeons.BLOODY_SUNDAY]: {
+    name: "Bloody Sunday",
+    sprite:
+      "https://external-preview.redd.it/mJjUWHxEKQ674NI4m7hUSJ108UlpTgTH2vWSmwMHfdA.jpg?auto=webp&s=6c0601add4b5a74185844ebaff16bebb3ada41a5",
+    emoji: "🖥️",
+    description: `The site of the terrifying massacre and sacrifice known as Bloody Sunday. First, capture Zapdos from the Power Plant. Then, retrieve it from the PC...`,
+    bosses: ["136-1", "145-1"],
+    difficulties: {
+      [difficulties.HARD]: {
+        phases: [
+          {
+            rows: 3,
+            cols: 5,
+            pokemons: [
+              {
+                speciesId: "145",
+                level: 90,
+                position: 8,
+              },
+              {
+                speciesId: "101",
+                level: 85,
+                position: 11,
+              },
+              {
+                speciesId: "82",
+                level: 85,
+                position: 12,
+              },
+              {
+                speciesId: "26",
+                level: 85,
+                position: 13,
+              },
+              {
+                speciesId: "82",
+                level: 85,
+                position: 14,
+              },
+              {
+                speciesId: "101",
+                level: 85,
+                position: 15,
+              },
+            ],
+          },
+          {
+            rows: 3,
+            cols: 5,
+            pokemons: [
+              {
+                speciesId: "32",
+                level: 95,
+                position: 1,
+              },
+              {
+                speciesId: "44",
+                level: 95,
+                position: 2,
+              },
+              {
+                speciesId: "20",
+                level: 95,
+                position: 3,
+              },
+              {
+                speciesId: "83",
+                level: 95,
+                position: 4,
+              },
+              {
+                speciesId: "32",
+                level: 95,
+                position: 5,
+              },
+              {
+                speciesId: "48",
+                level: 95,
+                position: 6,
+              },
+              {
+                speciesId: "46",
+                level: 95,
+                position: 7,
+              },
+              {
+                speciesId: "74",
+                level: 95,
+                position: 8,
+              },
+              {
+                speciesId: "102",
+                level: 95,
+                position: 9,
+              },
+              {
+                speciesId: "48",
+                level: 95,
+                position: 10,
+              },
+              {
+                speciesId: "136-1",
+                level: 100,
+                position: 12,
+              },
+              {
+                speciesId: "145-1",
+                level: 100,
+                position: 14,
+              },
+            ],
+          },
+        ],
+        rewards: {
+          backpack: {
+            [backpackCategories.MATERIALS]: {
+              [backpackItems.KNOWLEDGE_SHARD]: 7,
+              [backpackItems.EMOTION_SHARD]: 7,
+              [backpackItems.WILLPOWER_SHARD]: 7,
+            },
+          },
+        },
+      },
+    },
+  },
 });
 
 /** @typedef {Enum<raids>} RaidEnum */

--- a/src/services/spawn.js
+++ b/src/services/spawn.js
@@ -29,7 +29,7 @@ const { giveNewPokemons } = require("./gacha");
 const { getGuildData } = require("./guild");
 
 const SPAWN_TIME =
-  process.env.STAGE === stageNames.ALPHA ? 30 * 60 * 1000 : 120 * 60 * 1000;
+  process.env.STAGE === stageNames.ALPHA ? 30 * 60 * 1000 : 60 * 60 * 1000;
 // const SPAWN_TIME_VARIANCE =
 //  process.env.STAGE === stageNames.ALPHA ? 3 * 60 * 1000 : 30 * 60 * 1000;
 // blacklist emoji servers


### PR DESCRIPTION
### 1.2.1 Twitch Plays Pokemon (Re-Run)

- Twitch Plays Pokemon Re-run: Celebrating Twitch Plays Pokemon Anniversary
  - Catch limited time TPP-inspired Pokemon in `/gacha`
  - Play limited time `/pve` and `/dungeons`
  - Buffed AA-j and AIR
- (Experimental) Buffed the average spawn delay 2hrs -> 1hr